### PR TITLE
Well that ended up being super simple....

### DIFF
--- a/test/API/APITests.robot
+++ b/test/API/APITests.robot
@@ -51,11 +51,6 @@ Validate Response Negative Tests
 # --- Identity Key found in actual list dictionaries but some keys mismatch error --------------------------------------
     ${not_match3}       ${json_actual_5}    ${list_expected_1}      ${NONE}         ${FALSE}        apple
 # --- Top Level only mismatch on lists comparison ----------------------------------------------------------------------
-
-Validate Response Negative Tests - Broken
-    [Tags]    Broken
-    [Template]      Validate Response Contains Expected Response Errors Template
-#   Error               JSON Actual         Expected Dict           Ignored Keys    Full List       Identity Key     **kwargs
     ${top_only_err}     ${json_actual_3}    ${list_expected_5}      ${NONE}         ${TRUE}         ${NONE}
 # --- Top Level only mismatch on lists date comparisons ----------------------------------------------------------------
 
@@ -83,11 +78,6 @@ Validate Response List Negative Tests
     ${not_match1}       ${json_actual_1}    ${dict_expected_2}      ${NONE}
     ${not_match1}       ${json_actual_1}    ${dict_expected_2}      whatever
     ${list_dict_err}    ${json_actual_2}    ${dict_expected_2}      ${NONE}
-
-Validate Response List Negative Tests - Broken
-    [Tags]    Broken
-    [Template]      Validate Response Contains Expected List Response Errors Template
-#   Error               JSON Actual         Expected Dict           Ignored Keys
     ${not_match2}       ${json_actual_5}    ${list_expected_6}      ${NONE}
 
 Verify Items Within Response Positive Tests
@@ -167,7 +157,6 @@ Key By Key Validator Positive Tests - Dates
     ${wo_example_not_close}     ${wo_example}           ${unmatched_keys_8}
 
 Key By Key Validator Negative Tests
-    [Tags]    Broken
     [Template]      Key By Key Validator Errors Template
 #   Error String            Actual Dictionary               Expected Dictionary            Ignored Keys        Unmatched Keys
     ${bad_array_err_1}      ${dict_actual_8}                ${dict_expected_9}
@@ -189,13 +178,13 @@ Date String Comparator Negative Tests
 *** Keywords ***
 Validate Response Contains Expected Response Errors Template
     [Arguments]     ${error}    ${json_actual}      ${expected_dict}    ${ignored_keys}=${NONE}     ${id_key}=${EMPTY}    ${top_level}=${FALSE}    &{kwargs}
-    Run Keyword And Expect Error    ${error}
+    Run Keyword And Expect Error    EQUALS: ${error}
     ...     Validate Response Contains Expected Response
     ...     ${json_actual}      ${expected_dict}    ${ignored_keys}     ${id_key}    ${top_level}    &{kwargs}
 
 Validate Response Contains Expected List Response Errors Template
     [Arguments]     ${error}    ${json_actual}      ${expected_dict}    ${ignored_keys}=${NONE}   ${full_list_validation}=${True}
-    Run Keyword And Expect Error    ${error}
+    Run Keyword And Expect Error    EQUALS: ${error}
     ...     Validate Response Contains Expected Response
     ...     ${json_actual}      ${expected_dict}    ${ignored_keys}    ${full_list_validation}
 
@@ -239,6 +228,6 @@ Key By Key Validator Testing Template
 
 Key By Key Validator Errors Template
     [Arguments]     ${error}    ${actual_dictionary}  ${expected_dictionary}   ${ignored_keys}=${EMPTY}   ${unmatched_keys}=@{EMPTY}
-    Run Keyword And Expect Error    ${error}
+    Run Keyword And Expect Error    EQUALS: ${error}
     ...         Key By Key Validator
     ...         ${actual_dictionary}    ${expected_dictionary}    ${ignored_keys}   ${unmatched_keys}


### PR DESCRIPTION
Fixes #54 

https://robotframework.org/robotframework/latest/libraries/BuiltIn.html#Run%20Keyword%20And%20Expect%20Error

After some hours of trying to get this all to work it seems there is a prefix you can add to the beginning of the expected error message. By default this keyword uses [glob wildcards](https://facelessuser.github.io/wcmatch/glob/) which apparently our error messages sometimes use. By forcing the EQUALS prefix we ignore the wildcards and check for an exact match.